### PR TITLE
複数人で同時にスコア入力した際に、衝突して変更が失われる不具合の軽減

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent, ComponentProps, useState } from 'react'
-import { deepCopy, filledArray, lastOfArray } from '../utils/utils'
+import { lastOfArray } from '../utils/utils'
 import { ScoreTable } from './ScoreTable'
 import { BaseLayout } from '../layouts/BaseLayout'
 import { Section } from './Section'
@@ -13,7 +13,8 @@ import { IRound } from '../interfaces/round'
 
 type Props = {
   rounds: IRound[]
-  setRounds: (rounds: IRound[]) => void
+  addRound: (numberOfPlayers: number) => void
+  setScore: (roundIndex: number, playerIndex: number, score: number) => void
   players: string[]
   setPlayers: (players: string[]) => void
   option: IOption
@@ -23,7 +24,8 @@ type Props = {
 
 export const HomePage: React.FC<Props> = ({
   rounds,
-  setRounds,
+  addRound,
+  setScore,
   players,
   setPlayers,
   option,
@@ -59,9 +61,7 @@ export const HomePage: React.FC<Props> = ({
     roundIndex,
     index
   ) => {
-    const newRounds = deepCopy(rounds)
-    newRounds[roundIndex][index] = score
-    setRounds(newRounds)
+    setScore(roundIndex, index, score)
   }
 
   const handleAddRound = (): void => {
@@ -73,9 +73,7 @@ export const HomePage: React.FC<Props> = ({
       setErrors(['スコアが未入力のプレイヤーがいます'])
       return
     }
-    const newRounds = deepCopy(rounds)
-    newRounds.push(filledArray<number>(players.length, 0))
-    setRounds(newRounds)
+    addRound(players.length)
   }
 
   return (

--- a/src/components/SelectCardModal.tsx
+++ b/src/components/SelectCardModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { CARDS } from '../constants/cards'
 import Image from 'next/image'
 import { ICard } from '../interfaces/card'
@@ -20,12 +20,25 @@ export const SelectCardModal: React.FC<Props> = ({
 }) => {
   const [selectedCards, setSelectedCards] = useState<ICard[]>([])
 
-  useEffect(() => {
-    const score = selectedCards
-      .map((card) => card.score)
-      .reduce((previousValue, currentValue) => previousValue + currentValue, 0)
+  const isFirstRender = useRef(false)
 
-    onChange(score)
+  useEffect(() => {
+    isFirstRender.current = true
+  }, [])
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+    } else {
+      const score = selectedCards
+        .map((card) => card.score)
+        .reduce(
+          (previousValue, currentValue) => previousValue + currentValue,
+          0
+        )
+
+      onChange(score)
+    }
   }, [selectedCards])
 
   const handleOnClickCard = (selectedCard: ICard) => {

--- a/src/containers/HomeContainer.tsx
+++ b/src/containers/HomeContainer.tsx
@@ -5,7 +5,7 @@ import { useOption } from '../hooks/use-option'
 import { initializeDatabase } from '../plugins/firebase'
 
 export const HomeContainer = () => {
-  const [rounds, setRounds] = useRounds()
+  const { rounds, addRound, setScore } = useRounds()
   const [players, setPlayers] = usePlayers()
   const [option, setOption] = useOption()
 
@@ -13,7 +13,8 @@ export const HomeContainer = () => {
     <HomePage
       {...{
         rounds,
-        setRounds,
+        addRound,
+        setScore,
         players,
         setPlayers,
         option,

--- a/src/hooks/use-rounds.ts
+++ b/src/hooks/use-rounds.ts
@@ -1,21 +1,38 @@
 import { IRound } from '../interfaces/round'
 import { useEffect, useState } from 'react'
 import { roundsRef } from '../plugins/firebase'
+import { deepCopy, filledArray } from '../utils/utils'
 
 type IRounds = IRound[]
 
-export const useRounds = (): [IRounds, (rounds: IRounds) => void] => {
+export const useRounds = (): {
+  rounds: IRounds
+  addRound: (numberOfPlayers: number) => void
+  setScore: (roundIndex: number, playerIndex: number, score: number) => void
+} => {
   const [rounds, setRounds] = useState<IRounds>([])
 
   useEffect(() => {
     roundsRef.on('value', (snapshot) => {
-      setRounds(snapshot.val() ?? [])
+      setRounds(snapshot.val() ? Object.values(snapshot.val()) : [])
     })
   }, [])
 
-  const updateDatabase = async (newRounds: IRounds) => {
-    await roundsRef.set(newRounds)
+  return {
+    rounds,
+    setScore: async (
+      roundIndex: number,
+      playerIndex: number,
+      score: number
+    ) => {
+      await roundsRef.child(`${roundIndex}/${playerIndex}`).set(score)
+    },
+    addRound: async (numberOfPlayers: number) => {
+      await roundsRef.transaction((currentRounds) => {
+        const newRounds = currentRounds === null ? [] : deepCopy(currentRounds)
+        newRounds.push(filledArray<number>(numberOfPlayers, 0))
+        return newRounds
+      })
+    },
   }
-
-  return [rounds, updateDatabase]
 }

--- a/src/test/pages/index.test.tsx
+++ b/src/test/pages/index.test.tsx
@@ -18,7 +18,8 @@ describe('Home page', () => {
           rescueThird: false,
           magnification: 1,
         }}
-        setRounds={handleSet}
+        addRound={handleSet}
+        setScore={handleSet}
         setPlayers={handleSet}
         setOption={handleSet}
         initializeDatabase={handleSet}


### PR DESCRIPTION
- firebaseのスコアを全書き換えではなく単一書き換えに変えて衝突しづらくした